### PR TITLE
Add support for command line options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/bin/docha
+++ b/bin/docha
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 
 var docha = require("../lib/docha");
+var options = require('commander');
 
-docha({
-	// TODO: options
-}, function (err) {
+options.
+	option('-p, --test-path [path]', 'File/directory to document').
+	option('-o, --output [path]', 'File to write to').
+	option('-C, --no-code', 'Do not include code in the generated documentation').
+	parse(process.argv);
+
+docha(options,
+function (err) {
 	if ( err ) {
 		console.error(err);
 		process.exit(-1);

--- a/bin/docha
+++ b/bin/docha
@@ -14,8 +14,6 @@ options.
 	option('-e, --escape <strings>', 'Escape each of these comma-separated strings in descriptions', list, []).
 	parse(process.argv);
 
-  console.log(options.escape);
-
 docha(options,
 function (err) {
 	if ( err ) {

--- a/bin/docha
+++ b/bin/docha
@@ -3,11 +3,18 @@
 var docha = require("../lib/docha");
 var options = require('commander');
 
+function list(val) {
+  return val.split(',');
+}
+
 options.
 	option('-p, --test-path [path]', 'File/directory to document').
 	option('-o, --output [path]', 'File to write to').
 	option('-C, --no-code', 'Do not include code in the generated documentation').
+	option('-e, --escape <strings>', 'Escape each of these comma-separated strings in descriptions', list, []).
 	parse(process.argv);
+
+  console.log(options.escape);
 
 docha(options,
 function (err) {

--- a/lib/docha.js
+++ b/lib/docha.js
@@ -14,12 +14,20 @@ module.exports = function (options, callback) {
 
 	// Set some globals, emulate mocha
 	global.describe = function (description, fn) {
+		options.escape.forEach(function (substring, index, array) {
+			description = description.replace(new RegExp('('+substring+')', 'g'), '\\'+substring);
+		});
+
 		block = makeBlock(description, block);
 		block.parent.children.push(block);
 		fn();
 		block = block.parent;
 	}
 	global.it = function (behaviour, fn) {
+		options.escape.forEach(function (substring, index, array) {
+			behaviour = behaviour.replace(new RegExp('('+substring+')', 'g'), '\\'+substring);
+		});
+
 		var code = fn.toString();
 		code = code.slice(code.indexOf('{')+1);
 		code = code.slice(0, code.lastIndexOf('}')-1);

--- a/lib/docha.js
+++ b/lib/docha.js
@@ -38,6 +38,10 @@ module.exports = function (options, callback) {
 			code: code
 		});
 	}
+	global.before = function() {}
+	global.after = function() {}
+	global.beforeEach = function() {}
+	global.afterEach = function() {}
 	global.docha = {
 		doc: function (text) {
 			block.children.push(text)

--- a/lib/docha.js
+++ b/lib/docha.js
@@ -74,19 +74,22 @@ function writeOutput(options, block, callback) {
 	fs.writeFile(
 		output,
 		block.children.map(function (block) {
-			return toMarkdown(block, 1);
+			return toMarkdown(options, block, 1);
 		}).join('\n\n'),
 		'utf8',
 		callback
 	);
 }
-function toMarkdown(block, depth) {
+function toMarkdown(options, block, depth) {
 	if ( block.behaviour ) {
-		return ' ' + block.behaviour + "\n\n```\n" + block.code + "\n```\n";
+		var text = ' ' + block.behaviour + '\n';
+		if (options.code)
+			text += "\n```\n" + block.code + "\n```\n";
+		return text;
 	} else if (block.block) {
 		return "#####".slice(0, depth) + ' ' + block.block + '\n' +
 			block.children.map(function (child) {
-				return toMarkdown(child, depth + 1);
+				return toMarkdown(options, child, depth + 1);
 			}).join('\n\n');
 	} else {
 		return block;

--- a/package.json
+++ b/package.json
@@ -25,10 +25,8 @@
     "url": "https://github.com/tehsenaus/docha/issues"
   },
   "dependencies": {
+    "commander": "^2.7.1",
     "glob": "~3.2.6",
     "string": "~1.5.1"
-  },
-  "devDependencies": {
-    "commander": "^2.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "dependencies": {
     "glob": "~3.2.6",
     "string": "~1.5.1"
+  },
+  "devDependencies": {
+    "commander": "^2.7.1"
   }
 }


### PR DESCRIPTION
This pull request adds support for passing command line options to Docha using the [Commander.js](https://github.com/tj/commander.js) library. The following options are supported:

```
$ ./bin/docha -h

  Usage: docha [options]

  Options:

    -h, --help              output usage information
    -p, --test-path [path]  File/directory to document
    -o, --output [path]     File to write to
    -C, --no-code           Do not include code in the generated documentation
    -e, --escape <strings>  Escape each of these comma-separated strings in descriptions
```
