### PR TITLE
Allow non-documented files to be required ahead of files to be documented

### DIFF
--- a/bin/docha
+++ b/bin/docha
@@ -12,6 +12,7 @@ options.
 	option('-o, --output [path]', 'File to write to').
 	option('-C, --no-code', 'Do not include code in the generated documentation').
 	option('-e, --escape <strings>', 'Escape each of these comma-separated strings in descriptions', list, []).
+	option('-r, --requirements-path [path]', 'File/directory to `require()` before documentation can be created').
 	parse(process.argv);
 
 docha(options,

--- a/bin/docha
+++ b/bin/docha
@@ -12,7 +12,7 @@ options.
 	option('-o, --output [path]', 'File to write to').
 	option('-C, --no-code', 'Do not include code in the generated documentation').
 	option('-e, --escape <strings>', 'Escape each of these comma-separated strings in descriptions', list, []).
-	option('-r, --requirements-path [path]', 'File/directory to `require()` before documentation can be created').
+	option('-r, --require [path]', 'File/directory to `require()` before documentation can be created').
 	parse(process.argv);
 
 docha(options,

--- a/lib/docha.js
+++ b/lib/docha.js
@@ -8,7 +8,9 @@ module.exports = function (options, callback) {
 	var testPath = options.testPath || "test/**/*.js";
 	testPath = path.join(process.cwd(), testPath);
 	var requirementsPath = options.requirementsPath;
-	requirementsPath = path.join(process.cwd(), requirementsPath);
+	if (requirementsPath) {
+		requirementsPath = path.join(process.cwd(), requirementsPath);
+	}
 
 	// Some context
 	var root = makeBlock("root"),

--- a/lib/docha.js
+++ b/lib/docha.js
@@ -7,7 +7,7 @@ var path = require("path"),
 module.exports = function (options, callback) {
 	var testPath = options.testPath || "test/**/*.js";
 	testPath = path.join(process.cwd(), testPath);
-	var requirementsPath = options.requirementsPath;
+	var requirementsPath = options.require;
 	if (requirementsPath) {
 		requirementsPath = path.join(process.cwd(), requirementsPath);
 	}

--- a/lib/docha.js
+++ b/lib/docha.js
@@ -7,6 +7,8 @@ var path = require("path"),
 module.exports = function (options, callback) {
 	var testPath = options.testPath || "test/**/*.js";
 	testPath = path.join(process.cwd(), testPath);
+	var requirementsPath = options.requirementsPath;
+	requirementsPath = path.join(process.cwd(), requirementsPath);
 
 	// Some context
 	var root = makeBlock("root"),
@@ -61,6 +63,15 @@ module.exports = function (options, callback) {
 		}
 	}
 
+	if(requirementsPath) {
+		glob(requirementsPath, function (err, files) {
+			if (err) return callback(err);
+
+			files.forEach(function (file) {
+				require(file);
+			});
+		})
+	}
 
 	glob(testPath, function (err, files) {
 		if (err) return callback(err);
@@ -129,7 +140,7 @@ function buildLegend(options, block, depth){
 	if (block.block){
 		var url = prefix + block.block.toLowerCase().split(' ').join('-');
 
-		return Array(depth).join('    ') + '* [' + block.block + '](' +  url + ')\n' + 
+		return Array(depth).join('    ') + '* [' + block.block + '](' +  url + ')\n' +
 		block.children.map(function(child){
 			return buildLegend(options, child, depth + 1);
 		}).join('');


### PR DESCRIPTION
I have a single file that I load ahead of my test files that imports `sinon` and other modules globally so that I don't have to repeat the requires in every test file. However, when I try to run docha against just my test files, I get errors like this:

    ReferenceError: sinon is not defined

This change allows the user to specify a set of files to `require()` within Docha so that the environment is prepared for calling `require()` on the test files.