### PR TITLE
Fix legend items broken links

### DIFF
--- a/lib/docha.js
+++ b/lib/docha.js
@@ -142,7 +142,7 @@ function buildLegend(options, block, depth){
 	if (block.block){
 		var url = prefix + block.block.toLowerCase().split(' ').join('-');
 
-		return Array(depth).join('    ') + '* [' + block.block + '](' +  url + ')\n' +
+		return Array(depth).join('    ') + '* [' + block.block + '](#' +  url + ')\n' +
 		block.children.map(function(child){
 			return buildLegend(options, child, depth + 1);
 		}).join('');


### PR DESCRIPTION
Now legend is generated supposing that tests from  different js files are located in different .md files.
It gives links like https://localhost/linked-file
But is not right. Everything is located in one .md, so links must be in the form of https://localhost/#linked-file